### PR TITLE
fix migration assets not merged issue

### DIFF
--- a/src/main/groovy/com/fsryan/gradle/forsuredb/ForSureDbPlugin.groovy
+++ b/src/main/groovy/com/fsryan/gradle/forsuredb/ForSureDbPlugin.groovy
@@ -59,6 +59,7 @@ class ForSureDBPlugin implements Plugin<Project> {
                         hasSetDbMigrateCompileTaskDependency = true
                         TaskLog.i("forsuredb", "Setting ${dbMigrateTask.name} depends on ${v.javaCompile.name}")
                         dbMigrateTask.dependsOn(v.javaCompile)
+                        v.getMergeAssets().dependsOn(dbMigrateTask)
                         def kotlinCompileTask = project.tasks.findByName('compile' + GUtil.toCamelCase(v.name) + 'Kotlin')
                         if (kotlinCompileTask != null) {
                             TaskLog.i("forsuredb", "Setting ${dbMigrateTask.name} depends on ${kotlinCompileTask.name}")


### PR DESCRIPTION
Previously, when running dbMigrate, any generated migration files
would get copied to correct location, but they would not get merged
into the apks assets if the apk were assembled in the same build.
The solution was to make the variant's mergeAssets task depend upon
the dbMigrate task.